### PR TITLE
fix(Dockerfile): copy assets to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-buster as build-env
 WORKDIR /app
 ADD . /app
-run cd /app && \
+RUN cd /app && \
     npm install && \
     npm install typescript -g && \
     npm install ts-node -g && \
@@ -17,8 +17,10 @@ COPY --from=build-env /app/release/app/ /app
 COPY --from=build-env /app/release/views/  /views
 RUN apt-get update && apt-get  -y install ca-certificates ffmpeg &&  rm -rf /var/lib/apt/lists/*
 
-copy config.yaml.example /
-copy run.sh  /
+COPY assets /assets
+
+COPY config.yaml.example /
+COPY run.sh  /
 VOLUME [ "/config" ]
 EXPOSE 3000
 ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
The flags weren't showing up when built with Docker, because the assets folder was not copied to the container