### PR TITLE
Toggle option for scene preview in SceneCard

### DIFF
--- a/app/src/components/SceneCard.vue
+++ b/app/src/components/SceneCard.vue
@@ -8,7 +8,7 @@
               <div
                 @mouseenter="mouseenter"
                 @mouseleave="mouseleave"
-                v-if="hover"
+                v-if="previewSceneOnMouseHover && hover"
                 style="position: absolute: top: 0; left: 0; width: 100%; height: 100%"
               >
                 <div style="width: 100%; height: 100%; position: relative">
@@ -133,6 +133,10 @@ export default class SceneCard extends Mixins(SceneMixin) {
     if (this.value.thumbnail && this.value.thumbnail.color)
       return ensureDarkColor(this.value.thumbnail.color);
     return null;
+  }
+
+  get previewSceneOnMouseHover() {
+    return contextModule.scenePreviewOnMouseHover;
   }
 
   mouseenter() {

--- a/app/src/store/context.ts
+++ b/app/src/store/context.ts
@@ -12,6 +12,7 @@ class ContextModule extends VuexModule {
   fillActorCards = true;
 
   showSidenav = true; // TODO: store and load from localStorage
+  scenePreviewOnMouseHover = true;
 
   @Mutation
   toggleSidenav(bool: boolean) {
@@ -46,6 +47,11 @@ class ContextModule extends VuexModule {
   @Mutation
   setActorAspectRatio(val: number) {
     this.actorAspectRatio = val;
+  }
+
+  @Mutation
+  setScenePreviewOnMouseHover(val: boolean) {
+    this.scenePreviewOnMouseHover = val;
   }
 }
 

--- a/app/src/views/About.vue
+++ b/app/src/views/About.vue
@@ -46,6 +46,12 @@
                 <v-checkbox
                   color="primary"
                   hide-details
+                  label="Play scene preview on mouse hover"
+                  v-model="scenePreviewOnMouseHover"
+                />
+                <v-checkbox
+                  color="primary"
+                  hide-details
                   v-model="showCardLabels"
                   label="Show card labels on overview"
                 />
@@ -165,6 +171,15 @@ export default class About extends Vue {
 
   get scenePauseOnUnfocus() {
     return contextModule.scenePauseOnUnfocus;
+  }
+
+  set scenePreviewOnMouseHover(val: boolean) {
+    localStorage.setItem("pm_scenePreviewOnMouseHover", val.toString());
+    contextModule.setScenePreviewOnMouseHover(val);
+  }
+
+  get scenePreviewOnMouseHover() {
+    return contextModule.scenePreviewOnMouseHover;
   }
 
   toggleDarkMode() {


### PR DESCRIPTION
I have added an option to toggle the scene preview when hovering over a SceneCard. This option can be toggled in the "About" section. This PR can be seen as enhancement to #454.