### PR TITLE
New Config: add tests

### DIFF
--- a/test/config/index.spec.ts
+++ b/test/config/index.spec.ts
@@ -10,6 +10,7 @@ import YAML from "yaml";
 import { getConfig, checkConfig, resetLoadedConfig, watchConfig } from "../../src/config";
 import defaultConfig from "../../src/config/default";
 import { preserve } from "./index.fixture";
+import { invalidConfig } from "./schema.fixture";
 
 const configJSONFilename = path.resolve("config.test.json");
 const configYAMLFilename = path.resolve("config.test.yaml");
@@ -54,233 +55,233 @@ describe("config", () => {
     assert.isFalse(!!getConfig());
   });
 
-  it("if no file found, writes config.test.json and exits", async () => {
-    assert.isFalse(!!getConfig());
-    assert.isFalse(existsSync(configJSONFilename));
-    assert.isFalse((<any>exitStub).called);
+  describe("checkConfig", () => {
+    it("if no file found, writes config.test.json and exits", async () => {
+      assert.isFalse(!!getConfig());
+      assert.isFalse(existsSync(configJSONFilename));
+      assert.isFalse((<any>exitStub).called);
 
-    await checkConfig();
+      await checkConfig();
 
-    assert.isTrue(existsSync(configJSONFilename));
-    assert.isTrue((<any>exitStub).called);
-  });
-
-  it("loads existing config.test.json", async () => {
-    assert.isFalse(!!getConfig());
-    assert.isFalse(existsSync(configJSONFilename));
-
-    const testConfig = {
-      ...defaultConfig,
-      IS_TEST: true,
-    };
-
-    writeFileSync(configJSONFilename, JSON.stringify(testConfig, null, 2), {
-      encoding: "utf-8",
+      assert.isTrue(existsSync(configJSONFilename));
+      assert.isTrue((<any>exitStub).called);
     });
-    assert.isTrue(existsSync(configJSONFilename));
 
-    await checkConfig();
+    for (const targetFile of [configJSONFilename, configYAMLFilename]) {
+      it(`does NOT exit with default config written to ${targetFile}`, async () => {
+        assert.isFalse((<any>exitStub).called);
 
-    assert.deepEqual(testConfig, getConfig());
-  });
+        let formatter;
+        if (targetFile.includes(".json")) {
+          formatter = preserve.json;
+        } else if (targetFile.includes(".yaml")) {
+          formatter = preserve.yaml;
+        } else {
+          throw new Error("could not get formatter for test");
+        }
 
-  it("loads existing config.test.yaml", async () => {
-    assert.isFalse(!!getConfig());
-    assert.isFalse(existsSync(configJSONFilename));
-    assert.isFalse(existsSync(configYAMLFilename));
+        assert.isFalse(!!getConfig());
+        assert.isFalse(existsSync(configJSONFilename));
+        assert.isFalse(existsSync(configYAMLFilename));
 
-    const testConfig = {
-      ...defaultConfig,
-      IS_TEST: true,
-    };
+        writeFileSync(targetFile, formatter.stringify(defaultConfig), {
+          encoding: "utf-8",
+        });
+        assert.isTrue(existsSync(targetFile));
 
-    writeFileSync(configYAMLFilename, YAML.stringify(testConfig), {
-      encoding: "utf-8",
+        await checkConfig();
+
+        assert.isFalse((<any>exitStub).called);
+      });
+    }
+
+    for (const targetFile of [configJSONFilename, configYAMLFilename]) {
+      it(`exits when ${targetFile} format`, async () => {
+        assert.isFalse((<any>exitStub).called);
+
+        let formatter;
+        if (targetFile.includes(".json")) {
+          formatter = preserve.json;
+        } else if (targetFile.includes(".yaml")) {
+          formatter = preserve.yaml;
+        } else {
+          throw new Error("could not get formatter for test");
+        }
+
+        assert.isFalse(!!getConfig());
+        assert.isFalse(existsSync(configJSONFilename));
+        assert.isFalse(existsSync(configYAMLFilename));
+
+        writeFileSync(targetFile, formatter.stringify(invalidConfig), {
+          encoding: "utf-8",
+        });
+        assert.isTrue(existsSync(targetFile));
+
+        await checkConfig();
+
+        assert.isTrue((<any>exitStub).called);
+      });
+    }
+
+    it("loads existing config.test.json", async () => {
+      assert.isFalse(!!getConfig());
+      assert.isFalse(existsSync(configJSONFilename));
+
+      const testConfig = {
+        ...defaultConfig,
+        IS_TEST: true,
+      };
+
+      writeFileSync(configJSONFilename, JSON.stringify(testConfig, null, 2), {
+        encoding: "utf-8",
+      });
+      assert.isTrue(existsSync(configJSONFilename));
+
+      await checkConfig();
+
+      assert.deepEqual(testConfig, getConfig());
     });
-    assert.isTrue(existsSync(configYAMLFilename));
 
-    await checkConfig();
-
-    assert.deepEqual(testConfig, getConfig());
-  });
-
-  it("loads json before yaml", async () => {
-    assert.isFalse(!!getConfig());
-    assert.isFalse(existsSync(configJSONFilename));
-    assert.isFalse(existsSync(configYAMLFilename));
-
-    const jsonConfig = {
-      ...defaultConfig,
-      JSON: true,
-    };
-    const yamlConfig = {
-      ...defaultConfig,
-      YAML: true,
-    };
-
-    writeFileSync(configJSONFilename, JSON.stringify(jsonConfig, null, 2), {
-      encoding: "utf-8",
-    });
-    assert.isTrue(existsSync(configJSONFilename));
-    writeFileSync(configYAMLFilename, YAML.stringify(yamlConfig), {
-      encoding: "utf-8",
-    });
-    assert.isTrue(existsSync(configYAMLFilename));
-
-    await checkConfig();
-
-    const loadedConfig = getConfig();
-
-    assert.deepEqual(jsonConfig, loadedConfig);
-    assert.notDeepEqual(yamlConfig, loadedConfig);
-  });
-
-  it("reloads modified config.test.json without exiting", async () => {
-    assert.isFalse(!!getConfig());
-    assert.isFalse(existsSync(configJSONFilename));
-
-    const initialTestConfig = {
-      ...defaultConfig,
-      // point these to a real file so that the validation won't exit the program
-      FFMPEG_PATH: configJSONFilename,
-      FFPROBE_PATH: configJSONFilename,
-      IS_TEST: true,
-    };
-
-    writeFileSync(configJSONFilename, JSON.stringify(initialTestConfig, null, 2), {
-      encoding: "utf-8",
-    });
-    assert.isTrue(existsSync(configJSONFilename));
-
-    await checkConfig();
-
-    assert.deepEqual(initialTestConfig, getConfig());
-
-    const stopWatching = watchConfig();
-    // 2s should be enough to setup watcher
-    await new Promise((resolve) => setTimeout(resolve, 2 * 1000));
-
-    const secondaryTestConfig = {
-      ...getConfig(),
-      SECOND_TEST: true,
-    };
-    writeFileSync(configJSONFilename, JSON.stringify(secondaryTestConfig), {
-      encoding: "utf-8",
-    });
-    assert.isTrue(existsSync(configJSONFilename));
-
-    // 3s should be enough to detect file change and reload
-    await new Promise((resolve) => setTimeout(resolve, 3 * 1000));
-
-    assert.deepEqual(secondaryTestConfig, getConfig());
-
-    // Live reloading should not provoke an exit
-    assert.isFalse((<any>exitStub).called);
-
-    // We need to stop watching, otherwise mocha will consider
-    // that the test is still running
-    await stopWatching();
-  });
-
-  it("reloads modified config.test.yaml without exiting", async () => {
-    const initialTestConfig = {
-      ...defaultConfig,
-      // point these to a real file so that the validation won't exit the program
-      FFMPEG_PATH: configYAMLFilename,
-      FFPROBE_PATH: configYAMLFilename,
-      IS_TEST: true,
-    };
-
-    writeFileSync(configYAMLFilename, YAML.stringify(initialTestConfig), {
-      encoding: "utf-8",
-    });
-    assert.isTrue(existsSync(configYAMLFilename));
-
-    await checkConfig();
-
-    assert.deepEqual(initialTestConfig, getConfig());
-
-    const stopWatching = watchConfig();
-    // 2s should be enough to setup watcher
-    await new Promise((resolve) => setTimeout(resolve, 2 * 1000));
-
-    const secondaryTestConfig = {
-      ...getConfig(),
-      SECOND_TEST: true,
-    };
-    writeFileSync(configYAMLFilename, YAML.stringify(secondaryTestConfig), {
-      encoding: "utf-8",
-    });
-    assert.isTrue(existsSync(configYAMLFilename));
-
-    // 3s should be enough to detect file change and reload
-    await new Promise((resolve) => setTimeout(resolve, 3 * 1000));
-
-    assert.deepEqual(secondaryTestConfig, getConfig());
-
-    // Live reloading should not provoke an exit
-    assert.isFalse((<any>exitStub).called);
-
-    // We need to stop watching, otherwise mocha will consider
-    // that the test is still running
-    await stopWatching();
-  });
-
-  for (const targetFile of [configJSONFilename, configYAMLFilename]) {
-    it(`adds missing key, preserves ${targetFile} format`, async () => {
-      let formatter;
-      if (targetFile.includes(".json")) {
-        formatter = preserve.json;
-      } else if (targetFile.includes(".yaml")) {
-        formatter = preserve.yaml;
-      } else {
-        throw new Error("could not get formatter for test");
-      }
-
+    it("loads existing config.test.yaml", async () => {
       assert.isFalse(!!getConfig());
       assert.isFalse(existsSync(configJSONFilename));
       assert.isFalse(existsSync(configYAMLFilename));
 
-      const MISSING_KEY = "SCAN_INTERVAL";
-
-      // This test assumes that the missing key will be added with the
-      // value from 'defaultConfig'
-      const initialConfig = {
+      const testConfig = {
         ...defaultConfig,
+        IS_TEST: true,
       };
 
-      const incompleteConfig = { ...initialConfig };
-      delete incompleteConfig[MISSING_KEY];
-      assert.doesNotHaveAnyKeys(incompleteConfig, [MISSING_KEY]);
-
-      writeFileSync(targetFile, formatter.stringify(incompleteConfig), {
+      writeFileSync(configYAMLFilename, YAML.stringify(testConfig), {
         encoding: "utf-8",
       });
-      assert.isTrue(existsSync(targetFile));
-
-      let fileContents = readFileSync(targetFile, "utf-8");
-      let parsedFileContents;
-      assert.doesNotThrow(() => {
-        parsedFileContents = formatter.parse(fileContents);
-      });
-
-      // Before the real test, ensure an initial state of the
-      // actual file contents
-      assert.doesNotHaveAnyKeys(fileContents, [MISSING_KEY]);
-      assert.notDeepEqual(initialConfig, parsedFileContents);
+      assert.isTrue(existsSync(configYAMLFilename));
 
       await checkConfig();
 
-      fileContents = readFileSync(targetFile, "utf-8");
-
-      assert.doesNotThrow(() => {
-        // If parse does not throw, we can assume
-        // the contents still the same format
-        parsedFileContents = formatter.parse(fileContents);
-      });
-
-      assert.containsAllKeys(parsedFileContents, [MISSING_KEY]);
-      assert.deepEqual(initialConfig, parsedFileContents);
+      assert.deepEqual(testConfig, getConfig());
     });
-  }
+
+    it("loads json before yaml", async () => {
+      assert.isFalse(!!getConfig());
+      assert.isFalse(existsSync(configJSONFilename));
+      assert.isFalse(existsSync(configYAMLFilename));
+
+      const jsonConfig = {
+        ...defaultConfig,
+        JSON: true,
+      };
+      const yamlConfig = {
+        ...defaultConfig,
+        YAML: true,
+      };
+
+      writeFileSync(configJSONFilename, JSON.stringify(jsonConfig, null, 2), {
+        encoding: "utf-8",
+      });
+      assert.isTrue(existsSync(configJSONFilename));
+      writeFileSync(configYAMLFilename, YAML.stringify(yamlConfig), {
+        encoding: "utf-8",
+      });
+      assert.isTrue(existsSync(configYAMLFilename));
+
+      await checkConfig();
+
+      const loadedConfig = getConfig();
+
+      assert.deepEqual(jsonConfig, loadedConfig);
+      assert.notDeepEqual(yamlConfig, loadedConfig);
+    });
+
+    it("reloads modified config.test.json without exiting", async () => {
+      assert.isFalse(!!getConfig());
+      assert.isFalse(existsSync(configJSONFilename));
+
+      const initialTestConfig = {
+        ...defaultConfig,
+        // point these to a real file so that the validation won't exit the program
+        FFMPEG_PATH: configJSONFilename,
+        FFPROBE_PATH: configJSONFilename,
+        IS_TEST: true,
+      };
+
+      writeFileSync(configJSONFilename, JSON.stringify(initialTestConfig, null, 2), {
+        encoding: "utf-8",
+      });
+      assert.isTrue(existsSync(configJSONFilename));
+
+      await checkConfig();
+
+      assert.deepEqual(initialTestConfig, getConfig());
+
+      const stopWatching = watchConfig();
+      // 2s should be enough to setup watcher
+      await new Promise((resolve) => setTimeout(resolve, 2 * 1000));
+
+      const secondaryTestConfig = {
+        ...getConfig(),
+        SECOND_TEST: true,
+      };
+      writeFileSync(configJSONFilename, JSON.stringify(secondaryTestConfig), {
+        encoding: "utf-8",
+      });
+      assert.isTrue(existsSync(configJSONFilename));
+
+      // 3s should be enough to detect file change and reload
+      await new Promise((resolve) => setTimeout(resolve, 3 * 1000));
+
+      assert.deepEqual(secondaryTestConfig, getConfig());
+
+      // Live reloading should not provoke an exit
+      assert.isFalse((<any>exitStub).called);
+
+      // We need to stop watching, otherwise mocha will consider
+      // that the test is still running
+      await stopWatching();
+    });
+
+    it("reloads modified config.test.yaml without exiting", async () => {
+      const initialTestConfig = {
+        ...defaultConfig,
+        // point these to a real file so that the validation won't exit the program
+        FFMPEG_PATH: configYAMLFilename,
+        FFPROBE_PATH: configYAMLFilename,
+        IS_TEST: true,
+      };
+
+      writeFileSync(configYAMLFilename, YAML.stringify(initialTestConfig), {
+        encoding: "utf-8",
+      });
+      assert.isTrue(existsSync(configYAMLFilename));
+
+      await checkConfig();
+
+      assert.deepEqual(initialTestConfig, getConfig());
+
+      const stopWatching = watchConfig();
+      // 2s should be enough to setup watcher
+      await new Promise((resolve) => setTimeout(resolve, 2 * 1000));
+
+      const secondaryTestConfig = {
+        ...getConfig(),
+        SECOND_TEST: true,
+      };
+      writeFileSync(configYAMLFilename, YAML.stringify(secondaryTestConfig), {
+        encoding: "utf-8",
+      });
+      assert.isTrue(existsSync(configYAMLFilename));
+
+      // 3s should be enough to detect file change and reload
+      await new Promise((resolve) => setTimeout(resolve, 3 * 1000));
+
+      assert.deepEqual(secondaryTestConfig, getConfig());
+
+      // Live reloading should not provoke an exit
+      assert.isFalse((<any>exitStub).called);
+
+      // We need to stop watching, otherwise mocha will consider
+      // that the test is still running
+      await stopWatching();
+    });
+  });
 });

--- a/test/config/schema.fixture.ts
+++ b/test/config/schema.fixture.ts
@@ -1,0 +1,6 @@
+import defaultConfig from "../../src/config/default";
+
+export const invalidConfig = {
+  ...defaultConfig,
+  auth: false,
+};

--- a/test/config/schema.spec.ts
+++ b/test/config/schema.spec.ts
@@ -1,0 +1,27 @@
+import "mocha";
+
+import { assert } from "chai";
+
+import defaultConfig from "../../src/config/default";
+import { isValidConfig } from "../../src/config/schema";
+import { invalidConfig } from "./schema.fixture";
+
+describe("schema", () => {
+  describe("isValidConfig", () => {
+    it("default config is valid", () => {
+      const validationResult = isValidConfig(defaultConfig);
+      assert.notInstanceOf(validationResult, Error);
+      assert.isTrue(validationResult);
+    });
+
+
+    // Since we are simply using zod's validation, without custom value validation,
+    // we only need once test to verify the 'isValidConfig' function,
+    // since we do not want to duplicate the tests of the 'zod' package
+    it("dummy invalid config fails validation", () => {
+      const validationResult = isValidConfig(invalidConfig);
+      assert.instanceOf(validationResult, Error);
+      assert.isNotTrue(validationResult);
+    });
+  });
+});


### PR DESCRIPTION
- remove tests: auto insertion of missing config key
- add tests: process does not exit/exists if valid/invalid config
- add tests: config schema validator returns correct values for valid/invalid config